### PR TITLE
Fix always assume that some items may have abilities

### DIFF
--- a/bot/models/items.py
+++ b/bot/models/items.py
@@ -229,13 +229,16 @@ class Item(PrivateModelMixin, Document):
             "owner": {"$in": owners_list},
             "items_data.item_id": item_id
         }
-        from bot.modules.items.item import is_standart
+        from bot.modules.items.item import is_standart, get_data
         temp_item = {"item_id": item_id, "abilities": abilities or {}}
         if is_standart(temp_item):
             std_conditions = [
                 {"items_data.abilities": {"$exists": False}},
                 {"items_data.abilities": {}}
             ]
+            config_abilities = get_data(item_id).get('abilities', {})
+            if config_abilities:
+                std_conditions.append({"items_data.abilities": config_abilities})
             if abilities:
                 match_default = {}
                 for k, v in abilities.items():
@@ -293,13 +296,16 @@ class Item(PrivateModelMixin, Document):
             "owner": {"$in": owners_list},
             "items_data.item_id": item_id
         }
-        from bot.modules.items.item import is_standart
+        from bot.modules.items.item import is_standart, get_data
         temp_item = {"item_id": item_id, "abilities": abilities or {}}
         if is_standart(temp_item):
             std_conditions = [
                 {"items_data.abilities": {"$exists": False}},
                 {"items_data.abilities": {}}
             ]
+            config_abilities = get_data(item_id).get('abilities', {})
+            if config_abilities:
+                std_conditions.append({"items_data.abilities": config_abilities})
             if abilities:
                 match_default = {}
                 for k, v in abilities.items():
@@ -344,13 +350,16 @@ class Item(PrivateModelMixin, Document):
             "owner": {"$in": owners_list},
             "items_data.item_id": item_id
         }
-        from bot.modules.items.item import is_standart
+        from bot.modules.items.item import is_standart, get_data
         temp_item = {"item_id": item_id, "abilities": abilities or {}}
         if is_standart(temp_item):
             std_conditions = [
                 {"items_data.abilities": {"$exists": False}},
                 {"items_data.abilities": {}}
             ]
+            config_abilities = get_data(item_id).get('abilities', {})
+            if config_abilities:
+                std_conditions.append({"items_data.abilities": config_abilities})
             if abilities:
                 match_default = {}
                 for k, v in abilities.items():


### PR DESCRIPTION
Hi, this fix comes from when i was trying to transform the rarity of my dino to legendary

i have legendary egg, enough coins, and magic stone, but the bot keep saying: `❌ | You don't have all the items for transformation!`

i checked the code and found that it doesn't find the magic stone, the program assumes items (magic stone) have no abilities, while it actualy has abilities 

https://github.com/Rimuwu/DinoGochi/blob/08d99752c247750082a8599fe91a64f8f40354f3/bot/json/items/materials.json#L153-L156

my fix is, when some item has abilities, we can add it into the query, this will prevent the dino rarity transformation bug (the one that require magic stone)

